### PR TITLE
Added "dispatch-n" to list of example effects...

### DIFF
--- a/docs/Effects.md
+++ b/docs/Effects.md
@@ -61,7 +61,7 @@ And the `:dispatch` `key` instructs that an event should be
 dispatched. The `value` is the vector to dispatch.
 
 There's many other possible
-effects, like for example `:dispatch-later` or `:set-local-store`.
+effects, like for example `:dispatch-later`, `dispatch-n`, `:set-local-store`, etc.
 
 And so on. And so on. Which brings us to a problem.
 


### PR DESCRIPTION
I spent months searching for "re-frame multiple dispatch", but managed to somehow overlook `:dispatch-n` — until someone in Clojurian Slack channel pointed it out.  

I now see it referenced in source code and API docs.  But a little hint that it exists in this doc would have enabled me to find it right away.  Thank you!